### PR TITLE
fix(example): migrate deprecated Material buttons to modern widgets

### DIFF
--- a/example/lib/uiUtils.dart
+++ b/example/lib/uiUtils.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class UiUtils {
   static Widget createButton(String name, Function callback) {
-    return RaisedButton(
+    return ElevatedButton(
         onPressed: callback,
         child: Text(name),
         color: Colors.blue,


### PR DESCRIPTION
Migrates deprecated Material buttons in example code to current widgets:

- RaisedButton -> ElevatedButton
- FlatButton -> TextButton
- OutlineButton -> OutlinedButton

This removes analyzer deprecation warnings and aligns examples with Flutter stable.
No library code changed; examples only.